### PR TITLE
Bugfix/notifications enabled reversed

### DIFF
--- a/app/lib/services/period_notifications.dart
+++ b/app/lib/services/period_notifications.dart
@@ -60,7 +60,7 @@ class NotificationHelper {
   }) async {
     final bool areEnabled = await _settingsService.areNotificationsEnabled();
     final int daysBefore = await _settingsService.getNotificationDays();
-    if (!areEnabled) {
+    if (areEnabled) {
       const AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
         'scheduled_channel_id',
         'Period Alerts',


### PR DESCRIPTION
This meant that the notifications were actually scheduled if the setting was disabled. Whoops!