### PR TITLE
Hotfix/app/Incorrect last period system

### DIFF
--- a/app/lib/services/period_service.dart
+++ b/app/lib/services/period_service.dart
@@ -90,7 +90,7 @@ class PeriodService extends ChangeNotifier {
 
     try {
       _periodEntries = await _periodsRepo.readAllPeriods();
-      _lastPeriod = _periodEntries.lastOrNull;
+      _lastPeriod = _periodEntries.firstOrNull;
 
       _calculatePrediction();
       _updateUiState();


### PR DESCRIPTION
So annoying! it was _lastPeriod = _periodEntries.lastOrNull; when I should have use _lastPeriod = _periodEntries.firstOrNull;

Because the data sent back is orded DESC so the most recent value is at the top.